### PR TITLE
Update git scripts

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,1 +1,11 @@
-/share/*
+/share/asdf-versions
+/share/gem/
+/share/npm/
+/share/vim/plugged/
+/share/ipython/
+/share/iterm2/
+/share/delta/
+/share/direnv/
+/share/heroku/
+/share/yarn/
+/share/tilt-dev/

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -75,6 +75,7 @@ setup :gui_apps do
   cask_install :slack
   cask_install :spotify
   cask_install :sqlpro_studio
+  cask_install :tuple
   cask_install :vlc
   cask_install :zoom
 end

--- a/config/git/config
+++ b/config/git/config
@@ -107,8 +107,9 @@
 	side-by-side = true
 
 [pretty]
-	brief  = "%Cred%h%Creset %C(bold)%<(50,trunc)%s%Creset%Cgreen%>>(11)%cd%Creset %C(yellow)%+D%Creset"
-	select = "%Cred%h%Creset %C(bold)%<(50,trunc)%s%Creset %Cgreen%>>(20)%D%Creset"
+	brief    = "%Cred%h%Creset %C(bold)%<(50,trunc)%s%Creset%Cgreen%>>(11)%cd%Creset %C(yellow)%+D%Creset"
+	select   = "%Cred%h%Creset %C(bold)%<(50,trunc)%s%Creset %Cgreen%>>(20)%D%Creset"
+	extended = "%Cred%h%Creset %C(bold)%<(100,trunc)%s%Creset %Cgreen%>>(40)%D%Creset"
 
 [push]
 	default = simple

--- a/share/git/bin/git-checkout-branch
+++ b/share/git/bin/git-checkout-branch
@@ -16,7 +16,14 @@ if [[ "$1" =~ "--all" ]]; then
 fi
 
 # select a branch to checkout
-selected_branch="$(git branch "$@" | cut -c 3- | fzf --no-multi)"
+selected_branch="$(
+  git branch "$@" |
+  cut -c 3-       |
+  fzf --no-multi  \
+      --preview='git log --format=extended --color=always {+1}' \
+      --preview-window=right,80%
+)"
+
 current_head="$(git rev-parse --abbrev-ref HEAD)"
 
 if [[ -z $selected_branch || $selected_branch == "$current_head" ]]; then

--- a/share/git/bin/git-select-sha
+++ b/share/git/bin/git-select-sha
@@ -10,25 +10,26 @@ set -e
 
 # fuzzy-select a commit
 target_commit="$(
-    git log --format=select --color=always |\
-    fzf --ansi \
-        --exact \
-        --multi \
-        --no-sort \
-        --reverse \
-        --tiebreak=index \
-        --bind 'ctrl-f:preview-down' \
-        --bind 'ctrl-b:preview-up' \
-        $1 \
-        --preview='git show --color {+1}'
+  git log --format=select --color=always |
+  fzf --ansi \
+      --exact \
+      --multi \
+      --no-sort \
+      --reverse \
+      --tiebreak=index \
+      --bind 'ctrl-f:preview-down' \
+      --bind 'ctrl-b:preview-up' \
+      $1 \
+      --preview='git show --color {+1}' \
+      --preview-window=right,50%
 )"
 
 # slice out the SHA
 commit_shas="$(
-    echo "$target_commit" |\
-    awk '{ print $1 }'    |\
-    tr '\n' ' '           |\
-    awk '{$1=$1};1'
+  echo "$target_commit" |
+  awk '{ print $1 }'    |
+  tr '\n' ' '           |
+  awk '{$1=$1};1'
 )"
 
 if [[ ! -z "$commit_shas" ]]; then


### PR DESCRIPTION
This patch mainly updates git utility scripts — in particular, `git-checkout-branch` — in order to provide a preview of a given branch's commit history when selecting a branch to checkout.

Usage:

```sh
% git checkout-branch
# or
% g cob
```

![demo](https://user-images.githubusercontent.com/4433943/216196585-9f180553-d935-432d-a5b7-15c7249edc45.gif)


The other commits disable ignoring of the `share/git` directory in order to enable search tools to see the files therein, and add [Tuple](https://tuple.app) to the bootstrap script.